### PR TITLE
Parse each FF team's unique ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Virtual Env
+myvenv
+
+# Visual Studio
+.vscode

--- a/main.py
+++ b/main.py
@@ -1,14 +1,30 @@
 import os
 from bs4 import BeautifulSoup
 import requests
+import re
 
+attr_team_id = re.compile("teamId-[0-9]")
 
 NFL_FF_LEAGUE_PREFIX = "https://fantasy.nfl.com/league"
 NFL_FF_LEAGUE_ID = os.environ["NFL_FF_LEAGUE_ID"]
 NFL_FF_LEAGUE_URL = f'{NFL_FF_LEAGUE_PREFIX}/{NFL_FF_LEAGUE_ID}'
 
-res = requests.get(NFL_FF_LEAGUE_URL)
-res.raise_for_status()
+TEAM_ID_PREFIX = "teamId-"
 
-soup = BeautifulSoup(res.content, "html.parser")
-print(soup.prettify)
+def parse_team_id(span):
+    for val in span.attrs["class"]:
+        if val.startswith(TEAM_ID_PREFIX):
+            return val.strip(TEAM_ID_PREFIX)
+
+def main():
+    res = requests.get(NFL_FF_LEAGUE_URL)
+    res.raise_for_status()
+
+    soup = BeautifulSoup(res.content, "html.parser")
+    span_tags = soup.find_all("span", attrs={"class": attr_team_id})
+
+    team_ids = set(parse_team_id(span) for span in span_tags)
+    print(team_ids)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary
1. Get the HTML from the NFL FF League's home page
2. Search for the `teamId-` data attribute in the HTML
3. Parse each tag's ID and store it in the `team_ids` set

# Next Steps
Fetch each week's Game Center data for all the teams. The URL to use is 
```
https://fantasy.nfl.com/league/{LEAGUE_ID}/team/{TEAM_ID}/gamecenter
```