### PR TITLE
Refactor requests made to NFL and parsing logic

### DIFF
--- a/contentparser.py
+++ b/contentparser.py
@@ -1,0 +1,61 @@
+import re
+
+from bs4 import BeautifulSoup
+
+ATTR_TEAM_ID = re.compile("teamId-[0-9]")
+TEAM_ID_PREFIX = "teamId-"
+
+TEAM_ID = "TEAM_ID"
+TEAM_NAME = "TEAM_NAME"
+TEAM_OWNER = "TEAM_OWNER"
+
+TAG = "name"
+ATTRS = "attrs"
+
+SOUP_KWARGS_BY_FIELD = {
+    TEAM_ID: {
+        TAG: "span",
+        ATTRS: {"class": ATTR_TEAM_ID}
+    },
+    TEAM_NAME: {
+        TAG: "span",
+        ATTRS: {"class": "selecter-item"},
+    },
+    TEAM_OWNER: {TAG: "a", ATTRS: {"class": "userName"}},
+}
+
+
+def parse_team_ids(content: bytes):
+    soup = BeautifulSoup(content, "html.parser")
+    team_id_kwargs = SOUP_KWARGS_BY_FIELD[TEAM_ID]
+    span_tags = soup.find_all(**team_id_kwargs)
+
+    classes = []
+    for span in span_tags:
+        classes.extend(
+            cl for cl in span.attrs["class"] if cl.startswith(TEAM_ID_PREFIX)
+        )
+
+    return set(int(cl.strip(TEAM_ID_PREFIX)) for cl in classes)
+
+
+def parse_team_info(content: bytes, team_id: int):
+    soup = BeautifulSoup(content, "html.parser")
+
+    team_name_kwargs = SOUP_KWARGS_BY_FIELD[TEAM_NAME]
+    team_owner_kwargs = SOUP_KWARGS_BY_FIELD[TEAM_OWNER]
+
+    name = _parse_tag_text(soup, team_name_kwargs, {"data-value": team_id})
+    owner = _parse_tag_text(soup, team_owner_kwargs)
+
+    return (name, owner)
+
+
+def _parse_tag_text(soup: BeautifulSoup, kwargs: dict, custom_attrs={}):
+    kwargs[ATTRS] = kwargs[ATTRS] | custom_attrs
+    tag = soup.find(**kwargs)
+
+    if tag is None:
+        raise Exception(f"unable to find tag {kwargs[TAG]}")
+
+    return tag.get_text().strip().lower()

--- a/ffclient.py
+++ b/ffclient.py
@@ -1,0 +1,23 @@
+import requests
+
+
+class FantasyFootballClient:
+    def __init__(self, league_id: int):
+        self.league_id = league_id
+        self.base_url = f"https://fantasy.nfl.com/league/{league_id}"
+
+    def get_league_content(self) -> bytes:
+        return self._get_content(self.base_url)
+
+    def get_team_content(self, team_id: int) -> bytes:
+        url = self.base_url + f"/team/{team_id}"
+        return self._get_content(url)
+
+    def get_schedule_content(self, year: int) -> bytes:
+        url = self.base_url + f"/history/{year}/schedule"
+        return self._get_content(url)
+
+    def _get_content(self, url: str) -> bytes:
+        res = requests.get(url)
+        res.raise_for_status()
+        return res.content

--- a/main.py
+++ b/main.py
@@ -1,64 +1,26 @@
-from dataclasses import asdict
+import contentparser
+import ffclient
 import os
-import re
 import repo
-import requests
 
-from bs4 import BeautifulSoup
 from models import Team, Teams
 
-attr_team_id = re.compile("teamId-[0-9]")
 
 NFL_FF_LEAGUE_ID = os.environ["NFL_FF_LEAGUE_ID"]
-NFL_FF_LEAGUE_URL = f"https://fantasy.nfl.com/league/{NFL_FF_LEAGUE_ID}"
-NFL_FF_TEAM_URL = f"{NFL_FF_LEAGUE_URL}/team"
-
-TEAM_ID_PREFIX = "teamId-"
-
 TEAMS_JSON = "teams.json"
-NFL_FF_GAMECENTER_URL = f"{NFL_FF_TEAM_URL}/" + "{team_id}/gamecenter?week={week}"
 
 
 def fetch_teams():
-    res = requests.get(NFL_FF_LEAGUE_URL)
-    res.raise_for_status()
+    client = ffclient.FantasyFootballClient(NFL_FF_LEAGUE_ID)
+    team_ids = contentparser.parse_team_ids(client.get_league_content())
 
-    soup = BeautifulSoup(res.content, "html.parser")
-    span_tags = soup.find_all("span", attrs={"class": attr_team_id})
-
-    team_ids = set(parse_team_id(span) for span in span_tags)
     teams = []
-
     for team_id in team_ids:
-        res = requests.get(NFL_FF_TEAM_URL + f"/{team_id}")
-        res.raise_for_status()
-
-        soup = BeautifulSoup(res.content, "html.parser")
-
-        span = soup.find(
-            "span", attrs={"class": "selecter-item", "data-value": team_id}
-        )
-        if span is None:
-            raise Exception(
-                f"failed to find span tag containing the team name for team id: {team_id}"
-            )
-        name = span.get_text().strip().lower()
-
-        anchor = soup.find("a", attrs={"class": "userName"})
-        if anchor is None:
-            raise Exception(
-                f"failed to find anchor tag containing the team owner name for team id: {team_id}"
-            )
-        owner = anchor.get_text().strip().lower()
+        content = client.get_team_content(team_id)
+        (name, owner) = contentparser.parse_team_info(content, team_id)
         teams.append(Team(team_id, name, owner))
 
     return Teams(teams)
-
-
-def parse_team_id(span):
-    for val in span.attrs["class"]:
-        if val.startswith(TEAM_ID_PREFIX):
-            return int(val.strip(TEAM_ID_PREFIX))
 
 
 def main():
@@ -69,8 +31,6 @@ def main():
         print(f"sending requests to NFL to fetch team data")
         teams = fetch_teams()
         repo.commit(teams, TEAMS_JSON)
-
-    print(repo.read(TEAMS_JSON, Teams))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
I refactored the code in `main.py` because it bothered that `fetch_teams` was doing too much. I moved the http requests logic into its own file `ffclient.py` and the parsing logic into `contentparser.py`. The overall result is much cleaner. I hope to add unit tests to these files, but I will focus on getting the weekly data next.

I found a simpler way to get the each team's weekly score:
```
https://fantasy.nfl.com/league/{LEAGUE_ID}/history/{YEAR}/schedule
```

## What's next
- Finally save the weekly data into JSON