### PR TITLE
Scrape weekly games for the 2021 season

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,67 +1,28 @@
-from dataclasses import dataclass
-import contentparser
 import ffclient
 import os
 import repo
 
-from models import Team, Teams
 
+from models import Season
+from contentparser import ScheduleContentParser
 
 NFL_FF_LEAGUE_ID = os.environ["NFL_FF_LEAGUE_ID"]
 TEAMS_JSON = "teams.json"
 
 
-@dataclass
-class TeamStats:
-    team_id: int
-    team_name: str
-    record: str
-    streak: str
-    waiver: int
-    score: float
-
-
-@dataclass
-class Game:
-    home: TeamStats
-    away: TeamStats
-
-
-json = [{"year": 2021, "schedule": [[{}]]}]
-
-
-def fetch_scoring_data():
-    from bs4 import BeautifulSoup
-
-    client = ffclient.FantasyFootballClient(NFL_FF_LEAGUE_ID)
-    content = client.get_league_history(year=2021, week=1)
-
-    soup = BeautifulSoup(content, "html.parser")
-    items = soup("li", attrs={"class": "matchup"})
-
-    for item in items:
-        team_wraps = item.find_all("div", attrs={"class": "teamWrap"})
-        for team_wrap in team_wraps:
-            anchor = team_wrap.find("a", attrs={"class": "teamName"})
-            score = team_wrap.find("div", attrs={"class": "teamTotal"})
-            print(anchor.text, score.text)
-
-
-# def fetch_teams():
-#     client = ffclient.FantasyFootballClient(NFL_FF_LEAGUE_ID)
-#     team_ids = contentparser.parse_team_ids(client.get_league_content())
-
-#     teams = []
-#     for team_id in team_ids:
-#         content = client.get_team_content(team_id)
-#         (name, owner) = contentparser.parse_team_info(content, team_id)
-#         teams.append(Team(team_id, name, owner))
-
-#     return Teams(teams)
-
-
 def main():
-    fetch_scoring_data()
+    client = ffclient.FantasyFootballClient(NFL_FF_LEAGUE_ID)
+    seasons = []
+    for year in [2021]:
+        games = []
+        for week in range(1, 18):
+            content = client.get_league_history(year, week)
+
+            parser = ScheduleContentParser(content)
+            games.extend(parser.parse_games(week))
+        seasons.append(Season(year, games))
+
+    repo.commit(seasons[0], "season-2021.json")
 
 
 if __name__ == "__main__":

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -11,3 +11,30 @@ class Team:
 @dataclass
 class Teams:
     teams: list[Team]
+
+
+@dataclass
+class Game:
+    week: int
+    home_id: int
+    away_id: int
+    home_score: float
+    away_score: float
+
+
+@dataclass
+class Season:
+    year: int
+    games: list[Game]
+    standings: list[int] = field(default_factory=list)
+
+
+@dataclass
+class Seasons:
+    seasons: list[Season]
+
+
+@dataclass
+class League:
+    seasons: Seasons
+    teams: Teams


### PR DESCRIPTION
## Summary
- Implemented object-oriented design (see `ScheduleContentParser`) for scraping the 2021 season data
- I've defined the JSON structure, see `models.py`
- I was surprised to see the code actually work. Now I need to test it out for other seasons (i.e. 2019, 2020)

## What's next
- Refactor `contentparser.py` to follow the same OO design
- Run the entire scraping pipeline for 2021. I should produce the final JSON League result.


I'm going to start tracking the time it took for me to write this.
**Total time**: 63 minutes