### PR TITLE
Day 8: Scraping Regular Season Schedule Data + Airtable pivot

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,36 +1,30 @@
 import os
+import repo
+import models
 
-from models import Season, Seasons, League, Teams
-from contentparser import TeamParser, ScheduleContentParser
 from nflrequests import LeagueHistoryRequests
+from scraper import SeasonScraper
 
 NFL_FF_LEAGUE_ID = os.environ["NFL_FF_LEAGUE_ID"]
-WEEKS_IN_SEASON = [16, 16, 16, 16, 16, 16, 16, 17]
+NUM_WEEKS_IN_SEASON = [16, 16, 16, 16, 16, 16, 16, 17]
 SEASON_YEARS = [2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021]
-
-
-class LeagueScraper(object):
-    def __init__(self, requests: LeagueHistoryRequests):
-        self.requests = requests
-
-    def scrape():
-        return League(Seasons([]), Teams([]))
-
-    def _scrape_teams(self):
-        content = self.requests.fetch_teams()
-        parser = TeamParser(content)
-        return parser.parse_teams()
-
-    def _scrape_schedule(self, week: int):
-        content = self.requests.fetch_schedule(week)
-        parser = ScheduleContentParser(content)
-        return parser.parse_games()
 
 
 def main():
     requests = LeagueHistoryRequests(NFL_FF_LEAGUE_ID, 2021)
-    scraper = LeagueScraper(requests)
-    print(scraper._scrape_teams())
+    seasons = []
+    for i, year in enumerate(SEASON_YEARS):
+        if i < 5:
+            # temporary until I can send all requests or sleep between scraping
+            continue
+
+        num_weeks = NUM_WEEKS_IN_SEASON[i]
+        scraper = SeasonScraper(requests, year, num_weeks)
+        print(f"scraping Season {year}")
+        seasons.append(scraper.scrape())
+
+    league = models.League(seasons, [])
+    repo.commit(league, "league.json")
 
 
 if __name__ == "__main__":

--- a/models.py
+++ b/models.py
@@ -1,16 +1,16 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+
+
+GAME_TYPE_REGULAR = "REGULAR"
+GAME_TYPE_PLAYOFF = "PLAYOFF"
+GAME_TYPE_CONSOLATION = "CONSOLATION"
 
 
 @dataclass
 class Team:
-    id: int
+    nfl_id: int
     name: str = ""
     owner: str = ""
-
-
-@dataclass
-class Teams:
-    teams: list[Team]
 
 
 @dataclass
@@ -20,21 +20,16 @@ class Game:
     away_id: int
     home_score: float
     away_score: float
+    type: str
 
 
 @dataclass
 class Season:
     year: int
     games: list[Game]
-    standings: list[int] = field(default_factory=list)
-
-
-@dataclass
-class Seasons:
-    seasons: list[Season]
 
 
 @dataclass
 class League:
-    seasons: Seasons
-    teams: Teams
+    seasons: list[Season]
+    teams: list[Team]

--- a/nflrequests.py
+++ b/nflrequests.py
@@ -23,6 +23,7 @@ class LeagueHistoryRequests(object):
         return self._get_content(url, payload)
 
     def _get_content(self, url: str, payload={}) -> bytes:
+        print(f"sending request to {url}")
         res = requests.get(url, params=payload)
         res.raise_for_status()
         return res.content

--- a/repo.py
+++ b/repo.py
@@ -2,7 +2,7 @@ import dacite
 import json
 import os
 
-from dataclasses import dataclass, asdict
+from dataclasses import asdict
 from typing import TypeVar, Type
 
 

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,31 @@
+from models import Season, Team
+from contentparser import TeamParser, ScheduleParser
+from nflrequests import LeagueHistoryRequests
+
+
+class Scraper(object):
+    def __init__(self, requests: LeagueHistoryRequests):
+        self.requests = requests
+
+
+class SeasonScraper(Scraper):
+    def __init__(self, requests: LeagueHistoryRequests, year: int, num_weeks=17):
+        super().__init__(requests)
+        self.year = year
+        self.num_weeks = num_weeks
+
+    def scrape(self) -> Season:
+        games = []
+        for week in range(1, self.num_weeks + 1):
+            print(f"fetching week {week} content")
+            content = self.requests.fetch_schedule(week)
+            parser = ScheduleParser(content, week)
+            games.extend(parser.parse_schedule())
+        return Season(self.year, games)
+
+
+class TeamScraper(Scraper):
+    def scrape(self) -> list[Team]:
+        content = self.requests.fetch_teams()
+        parser = TeamParser(content)
+        return parser.parse_teams()


### PR DESCRIPTION
## Summary
- I've decided to ingest the data I'm scraping into Airtable, so it's easily shareable with my league mates
- I implemented the SeasonScraper to make scraping regular season data easier
- There was an interesting bug where I was sending 153 requests per season to NFL. I'm surprised they didn't ban my IP.

## What's next
- Play around with the Airtable API, so I can upload the data there