### PR TITLE
Add records to Season 2021 table in Airtable

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -11,11 +11,11 @@ AIRTABLE_BASE_ID = os.environ["AIRTABLE_BASE_ID"]
 table = Table(AIRTABLE_API_KEY, AIRTABLE_BASE_ID, "Teams")
 
 # clear records in table
-game_ids = []
-for games in table.iterate():
-    for game in games:
-        game_ids.append(game["id"])
-table.batch_delete(game_ids)
+team_ids = []
+for teams in table.iterate():
+    for team in teams:
+        team_ids.append(team["id"])
+table.batch_delete(team_ids)
 
 league = repo.read("league.json", League)
 
@@ -26,5 +26,39 @@ for season in league.seasons:
 
 # create records in table
 sorted_teams = sorted(teams_by_id.items())
+teams_records = []
 for _, team in sorted_teams:
-    print(table.create({"ID": team.nfl_id, "Name": team.name, "Owner": team.owner}))
+    teams_records.append(
+        table.create({"ID": team.nfl_id, "Name": team.name, "Owner": team.owner})
+    )
+
+# create team NFL ID to record ID
+record_id = {}
+for record in teams_records:
+    nfl_id = record["fields"]["ID"]
+    record_id[nfl_id] = record["id"]
+
+table = Table(AIRTABLE_API_KEY, AIRTABLE_BASE_ID, "Season 2021")
+
+# clear records in Season 2021
+game_ids = []
+for games in table.iterate():
+    for game in games:
+        game_ids.append(game["id"])
+table.batch_delete(game_ids)
+
+for season in league.seasons:
+    if season.year != 2021:
+        continue
+
+    for i, game in enumerate(season.games):
+        record = {
+            "ID": i,
+            "Week": game.week,
+            "Home Team": [record_id[game.home_id]],
+            "Away Team": [record_id[game.away_id]],
+            "Home Team Score": game.home_score,
+            "Away Team Score": game.away_score,
+            "Game Type": game.type,
+        }
+        table.create(record)


### PR DESCRIPTION
## Summary
Short session today. I found some bugs when I updated the Airtable "Season 2021" table with actual data. I'm tracking the bugs in the Issues tab.

I don't know if I want to create tables for the other seasons in the same base. Because I'm linking fields between games and teams. Airtable automatically shows which records are being linked. It's a lot for just one season, and I can imagine the data will look bad adding more seasons.

## What's Next
I need to refactor the `upload.py` file, and figure out how I want to link dataclass fields to Airtable fields. I'm thinking loading a static cofiguration.